### PR TITLE
Warmup multiplication not working as expected -> Fix

### DIFF
--- a/pytorch_warmup/base.py
+++ b/pytorch_warmup/base.py
@@ -9,15 +9,18 @@ class BaseWarmup(object):
         optimizer (Optimizer): an instance of a subclass of Optimizer
         warmup_params (list): warmup paramters
         last_step (int): The index of last step. (Default: -1)
+        warmup_period (int or list): Warmup period
     """
 
-    def __init__(self, optimizer, warmup_params, last_step=-1):
+    def __init__(self, optimizer, warmup_params, last_step=-1, warmup_period=0):
         if not isinstance(optimizer, Optimizer):
             raise TypeError('{} is not an Optimizer'.format(
                 type(optimizer).__name__))
         self.optimizer = optimizer
         self.warmup_params = warmup_params
         self.last_step = last_step
+        self.base_lrs = [group['lr'] for group in self.optimizer.param_groups]
+        self.warmup_period = warmup_period
         self.dampen()
 
     def state_dict(self):
@@ -46,10 +49,12 @@ class BaseWarmup(object):
         if step is None:
             step = self.last_step + 1
         self.last_step = step
-
-        for group, params in zip(self.optimizer.param_groups, self.warmup_params):
-            omega = self.warmup_factor(step, **params)
-            group['lr'] *= omega
+        if isinstance(self.warmup_period, int) and step < self.warmup_period:
+            for i, (group, params) in enumerate(zip(self.optimizer.param_groups, self.warmup_params)):
+                if isinstance(self.warmup_period,list) and step >= self.warmup_period[i]:
+                    continue
+                omega = self.warmup_factor(step, **params)
+                group['lr'] = omega * self.base_lrs[i]
 
     def warmup_factor(self, step, **params):
         raise NotImplementedError
@@ -87,7 +92,7 @@ class LinearWarmup(BaseWarmup):
     def __init__(self, optimizer, warmup_period, last_step=-1):
         group_count = len(optimizer.param_groups)
         warmup_params = get_warmup_params(warmup_period, group_count)
-        super(LinearWarmup, self).__init__(optimizer, warmup_params, last_step)
+        super().__init__(optimizer, warmup_params, last_step, warmup_period)
 
     def warmup_factor(self, step, warmup_period):
         return min(1.0, (step+1) / warmup_period)
@@ -105,7 +110,7 @@ class ExponentialWarmup(BaseWarmup):
     def __init__(self, optimizer, warmup_period, last_step=-1):
         group_count = len(optimizer.param_groups)
         warmup_params = get_warmup_params(warmup_period, group_count)
-        super(ExponentialWarmup, self).__init__(optimizer, warmup_params, last_step)
+        super().__init__(optimizer, warmup_params, last_step, warmup_period)
 
     def warmup_factor(self, step, warmup_period):
         return 1.0 - math.exp(-(step+1) / warmup_period)


### PR DESCRIPTION
Testing out `LinearWarmup` and `ExponentialWarmup`, I noticed the strange behavior that the learning-rate did not rise during the `warmup_period`. Instead, it decreased.
Looking at the code, I noticed that the current, and not the initial learning-rate was always multiplied with the dampening-factor. This lead to the decrease.

See below my implementation to produce the behavior I expected to see.
