### PR TITLE
Fix CI on macOS

### DIFF
--- a/.github/workflows/example-plots.yml
+++ b/.github/workflows/example-plots.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 8
       matrix:
         python-version: [3.7, 3.8]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-13, windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 8
       matrix:
         python-version: [3.7, 3.8]
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-13, windows-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
* Unavailable Python 3.7 on macOS 14
* Unavailable PyTorch 1.4 for Python 3.8 on macOS 14